### PR TITLE
Change name to avoid collisions with other project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "open-telemetry/opentelemetry",
+  "name": "open-telemetry/opentelemetry-meta",
   "type": "metapackage",
   "description": "OpenTelemetry metapackage",
   "keywords": ["opentelemetry", "otel", "open-telemetry", "tracing", "logging", "metrics"],


### PR DESCRIPTION
Solve https://github.com/open-telemetry/opentelemetry-php/issues/948

Since you have published this repository, Packagist has overriden (or maybe it was your intention) the package https://packagist.org/packages/open-telemetry/opentelemetry with this repository, then previous alpha versions of https://github.com/open-telemetry/opentelemetry-php/ are not longer available

As you can see in the issue, the repository cannot be required for a previous tag (like 0.0.13) in any service because Composer find this one instead of open-telemetry/opentelemetry-php